### PR TITLE
feat: add extraCurlArgs support for custom curl arguments

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -156,6 +156,12 @@ export class CuimpHttp implements CuimpInstance {
       }
     }
 
+    // Extra curl arguments (from config or defaults)
+    const extraArgs = config.extraCurlArgs ?? this.defaults.extraCurlArgs;
+    if (extraArgs && extraArgs.length > 0) {
+      args.push(...extraArgs);
+    }
+
     // Always capture headers: use -D - (dump headers to stdout) won't work nicely;
     // Instead use: -i to include headers in output, then split.
     args.push('-i');

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,14 @@ import type { CuimpOptions, CuimpRequestConfig } from './types/cuimpTypes'
 // Factory function for creating HTTP client instances
 export function createCuimpHttp(options?: CuimpOptions) {
   const core = new Cuimp(options)
-  return new CuimpHttp(core)
+  const defaults: Partial<CuimpRequestConfig> = {}
+  
+  // Pass extraCurlArgs from options to defaults if provided
+  if (options?.extraCurlArgs) {
+    defaults.extraCurlArgs = options.extraCurlArgs
+  }
+  
+  return new CuimpHttp(core, defaults)
 }
 
 // Convenience function for quick HTTP requests

--- a/src/types/cuimpTypes.ts
+++ b/src/types/cuimpTypes.ts
@@ -26,6 +26,7 @@ export interface CuimpRequestConfig {
   proxy?: string;
   insecureTLS?: boolean;
   signal?: AbortSignal;
+  extraCurlArgs?: string[]; // Additional curl arguments like --cookie, --cookie-jar, etc.
 }
 
 export interface CuimpResponse<T = any> {
@@ -46,6 +47,7 @@ export interface CuimpResponse<T = any> {
 export interface CuimpOptions {
   descriptor?: CuimpDescriptor
   path?: string
+  extraCurlArgs?: string[] // Global curl arguments applied to all requests
 }
 
 


### PR DESCRIPTION
# Summary
Add ability to pass additional curl arguments through [extraCurlArgs](vscode-file://vscode-app/c:/Users/jm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) option, enabling advanced use cases like cookie management, custom authentication, debugging flags, and other curl features.

## Features
+ ✅ Add [extraCurlArgs](vscode-file://vscode-app/c:/Users/jm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [CuimpRequestConfig](vscode-file://vscode-app/c:/Users/jm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (per-request configuration)
+ ✅ Add [extraCurlArgs](vscode-file://vscode-app/c:/Users/jm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [CuimpOptions](vscode-file://vscode-app/c:/Users/jm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (global defaults)
+ ✅ Arguments are appended to curl command before execution
+ ✅ Fully backward compatible (optional parameter)

## Use Cases
+ Cookie jar management: --cookie-jar, --cookie
+ Custom authentication: Headers, tokens
+ Proxy configuration: Additional proxy options
+ Debugging: -v, --trace, --trace-ascii
+ Any other curl command-line arguments

### Example Usage
Global configuration:
```ts
const scraper = createCuimpHttp({
  descriptor: { browser: 'chrome', version: '136' },
  extraCurlArgs: [
    '--cookie-jar', '/tmp/cookies.txt',
    '--cookie', '/tmp/cookies.txt'
  ]
});
```

Per-request configuration:
```ts
await scraper.get(url, {
  extraCurlArgs: ['-v', '--trace-ascii', '/tmp/trace.txt']
});
```

## Testing
+ ✅ All existing tests pass (22/22)
+ ✅ Cookie jar functionality verified (httpbin.org)
+ ✅ Real-world website scraping tested with session management
+ ✅ GBK-encoded Chinese novel website (780 chapters)

## Breaking Changes
None. This is a fully backward-compatible addition.