### PR TITLE
Fix version caching and add forceDownload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,10 @@ Configure which browser to impersonate:
 ```typescript
 interface CuimpDescriptor {
   browser?: 'chrome' | 'firefox' | 'edge' | 'safari'
-  version?: string  // e.g., '123', '124'
+  version?: string  // e.g., '123', '124', or 'latest' (default)
   architecture?: 'x64' | 'arm64'
   platform?: 'linux' | 'windows' | 'macos'
+  forceDownload?: boolean  // Force re-download even if binary exists
 }
 ```
 
@@ -391,15 +392,23 @@ try {
 Cuimp automatically manages curl-impersonate binaries:
 
 1. **Automatic Download**: Downloads the appropriate binary for your platform on first use
-2. **Force Download**: Always downloads fresh binaries to ensure consistency
-3. **Verification**: Checks binary integrity and permissions
-4. **Clean Storage**: Binaries are stored in `node_modules/cuimp/binaries/` (not in your project root)
-5. **Cross-Platform**: Automatically detects your platform and architecture
+2. **Version Matching**: Reuses cached binaries only if they match the requested version
+3. **Force Download**: Use `forceDownload: true` to bypass cache and always download fresh binaries
+4. **Verification**: Checks binary integrity and permissions
+5. **Clean Storage**: Binaries are stored in `~/.cuimp/binaries/` (user home directory)
+6. **Cross-Platform**: Automatically detects your platform and architecture
+
+### Version Behavior
+
+- **Specific version** (e.g., `'133'`): Uses cached binary if version matches, otherwise downloads
+- **'latest'** (default): Uses any cached binary, or downloads if none exists
+- **forceDownload**: Always downloads, ignoring cache (useful for always getting the actual latest version)
 
 ### Binary Storage Location
 
-- **Development**: `./node_modules/cuimp/binaries/`
-- **Production**: `./node_modules/cuimp/binaries/`
+- **Download location**: `~/.cuimp/binaries/` (user home directory)
+- **Search locations**: Also checks `node_modules/cuimp/binaries/` and system paths as fallback
+- **Shared across projects**: Downloaded binaries are reused between projects
 - **No Project Pollution**: Your project directory stays clean
 
 ### Supported Proxy Formats

--- a/src/types/cuimpTypes.ts
+++ b/src/types/cuimpTypes.ts
@@ -3,6 +3,7 @@ export interface CuimpDescriptor {
   version?: string
   architecture?: string
   platform?: string
+  forceDownload?: boolean  // Force re-download even if binary exists
 }
 
 export interface BinaryInfo {

--- a/src/validations/descriptorValidation.ts
+++ b/src/validations/descriptorValidation.ts
@@ -19,7 +19,10 @@ export const validateDescriptor = (descriptor: CuimpDescriptor) => {
     }
     
     // Only validate version if provided
-    if (descriptor.version && descriptor.version.length !== 3) {
-        throw new Error('Version must be in the format of XYZ')
+    if (descriptor.version) {
+        // Accept 'latest' as a special value
+        if (descriptor.version !== 'latest' && descriptor.version.length !== 3) {
+            throw new Error('Version must be in the format of XYZ or "latest"')
+        }
     }
 }


### PR DESCRIPTION
Hey!

Fixed an issue where the library was reusing cached binaries even when you asked for a different version. 

## What changed

**Version matching**: The cache now actually checks if the version matches before reusing a binary. So if you request `'133'` but have `'136'` cached, it'll download the right one instead of just using whatever's there.

**forceDownload option**: Added a new option to force re-downloading binaries even if they exist in cache. Pretty handy for always getting the actual latest version:

```js
const client = createCuimpHttp({
  descriptor: { 
    browser: 'chrome', 
    version: 'latest',
    forceDownload: true 
  }
});
```

**'latest' validation**: Fixed the validation that was rejecting `'latest'` as a version string (even though it's the default value lol).

**Docs update**: Clarified how version matching and binary storage actually work - where binaries get downloaded vs where they're searched for.