### PR TITLE
Run ci/cd, check pr, fix release doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: cuimp-ts-v${{ github.ref_name }}.tar.gz
+          files: cuimp-ts-${{ github.ref_name }}.tar.gz
           generate_release_notes: true
           body: |
             ## Installation Methods

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuimp",
-  "version": "1.3.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cuimp",
-      "version": "1.3.0",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "cuimp": "^1.1.2",

--- a/src/cuimp.ts
+++ b/src/cuimp.ts
@@ -7,7 +7,7 @@ class Cuimp {
   private descriptor: CuimpDescriptor
   private path: string
   private binaryInfo?: BinaryInfo
-  private logger: Pick<Console, 'log' | 'warn' | 'error'>
+  private logger: Logger
   
   constructor(options?: CuimpOptions) {
     this.descriptor = options?.descriptor || {}
@@ -46,9 +46,9 @@ class Cuimp {
       // Update the path
       this.path = this.binaryInfo.binaryPath
 
-      this.logger.log(`Binary verified: ${this.path}`)
+      this.logger.info(`Binary verified: ${this.path}`)
       if (this.binaryInfo.isDownloaded) {
-        this.logger.log(`Binary downloaded successfully (version: ${this.binaryInfo.version})`)
+        this.logger.info(`Binary downloaded successfully (version: ${this.binaryInfo.version})`)
       }
 
       return this.path
@@ -116,7 +116,7 @@ class Cuimp {
       // Build the command preview
       const command = `${binaryPath} -X ${upperMethod} "${url}"`
       
-      this.logger.log(`Command preview: ${command}`)
+      this.logger.info(`Command preview: ${command}`)
       return command
 
     } catch (error) {
@@ -184,11 +184,11 @@ class Cuimp {
         throw new Error('Binary path not found after processing')
       }
 
-      this.logger.log(`Binary ready: ${this.binaryInfo.binaryPath}`)
+      this.logger.info(`Binary ready: ${this.binaryInfo.binaryPath}`)
       if (this.binaryInfo.isDownloaded) {
-        this.logger.log(`Download completed (version: ${this.binaryInfo.version})`)
+        this.logger.info(`Download completed (version: ${this.binaryInfo.version})`)
       } else {
-        this.logger.log(`Using existing binary (version: ${this.binaryInfo.version})`)
+        this.logger.info(`Using existing binary (version: ${this.binaryInfo.version})`)
       }
 
       return this.binaryInfo

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -359,24 +359,24 @@ export const parseDescriptor = async (descriptor: CuimpDescriptor, logger: Logge
                 const versionMatches = version === 'latest' || existingVersion === version
 
                 if (versionMatches) {
-                    console.log(`Found existing binary: ${existingBinary}`)
+                    logger.info(`Found existing binary: ${existingBinary}`)
                     return {
                         binaryPath: existingBinary,
                         isDownloaded: false,
                         version: existingVersion || 'unknown'
                     }
                 } else {
-                    console.log(`Found binary version ${existingVersion}, but version ${version} was requested. Re-downloading...`)
+                    logger.warn(`Found binary version ${existingVersion}, but version ${version} was requested. Re-downloading...`)
                 }
             }
         } else {
-            console.log('forceDownload enabled, skipping cache...')
+            logger.info('forceDownload enabled, skipping cache...')
         }
 
         // Download binary if not found, version mismatch, or forceDownload enabled
-        console.log(`Downloading curl-impersonate for ${browser} on ${platform}-${architecture}...`)
+        logger.info(`Downloading curl-impersonate for ${browser} on ${platform}-${architecture}...`)
 
-        const downloadResult = await downloadAndExtractBinary(browser, architecture, platform, version)
+        const downloadResult = await downloadAndExtractBinary(browser, architecture, platform, version, logger)
 
         return {
             binaryPath: downloadResult.binaryPath,

--- a/src/types/cuimpTypes.ts
+++ b/src/types/cuimpTypes.ts
@@ -56,7 +56,7 @@ export interface CuimpOptions {
   descriptor?: CuimpDescriptor
   path?: string
   extraCurlArgs?: string[] // Global curl arguments applied to all requests
-  logger?: Pick<Console, 'log' | 'warn' | 'error'>
+  logger?: Logger
 }
 
 


### PR DESCRIPTION
Integrate custom logging and fix release workflow artifact naming to align with recent changes and correct release documentation.

The logging changes align the `Cuimp` API with the recently merged "feat: allow custom logging" PR, ensuring all informational/warning messages are routed through the new `Logger` abstraction. The release workflow fix addresses an issue where the release artifact was incorrectly named `cuimp-ts-vv...` instead of `cuimp-ts-v...`, preventing proper artifact attachment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5b939fa-0c39-4a9c-bc71-9e0f6d05e376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5b939fa-0c39-4a9c-bc71-9e0f6d05e376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

