### PR TITLE
Update regex to validate HTTP/2 response headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -285,7 +285,7 @@ export class CuimpHttp implements CuimpInstance {
     // Split by HTTP/ and process each block
     const httpBlocks = headerText.split(/(?=HTTP\/)/);
     const validBlocks = httpBlocks.filter(block => 
-      block.trim() && /^HTTP\/\d\.\d \d{3}/.test(block.trim())
+      block.trim() && (/^HTTP\/\d\.\d \d{3}/.test(block.trim()) || /^HTTP\/\d \d{3}/.test(block.trim()))
     );
     
     // Use the last valid HTTP response block


### PR DESCRIPTION
HTTP/2 response headers are not being parsed because the regex doesn't take it into consideration.
I updated the regex to include HTTP/2