### PR TITLE
Add common issue with docker to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,10 +827,11 @@ When running cuimp inside a Docker container, you may encounter the following er
 This occurs because the container does not have access to the required CA certificates.  
 To fix this, mount your host machine’s certificate directory into the container, for example:
 
-```docker-compose
+```yaml
 volumes:
   - /etc/ssl/certs:/etc/ssl/certs:ro
 ```
+
 This ensures cuimp can properly verify TLS certificates inside the container.
 
 ## 📄 License


### PR DESCRIPTION
Hello there, I try to use this tool and found an 'common' issue that I already fixed. 
So I think it's good to describe it in readme too.

I don't know did this is safe solution, but at least it works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Docker troubleshooting section to README explaining the CA certificate error and fix via mounting `/etc/ssl/certs` read-only.
> 
> - **Documentation**
>   - **README**: Add Docker troubleshooting for TLS verification error
>     - Describes error: `error setting certificate verify locations: CAfile: /etc/ssl/certs/ca-certificates.crt CApath: /etc/ssl/certs`
>     - Recommends mounting host CA certs into container: `volumes: - /etc/ssl/certs:/etc/ssl/certs:ro`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f57fc672ad8627dac94dd72bd67a84666db97a06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->