### PR TITLE
Pr 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,10 +827,11 @@ When running cuimp inside a Docker container, you may encounter the following er
 This occurs because the container does not have access to the required CA certificates.  
 To fix this, mount your host machine’s certificate directory into the container, for example:
 
-```docker-compose
+```yaml
 volumes:
   - /etc/ssl/certs:/etc/ssl/certs:ro
 ```
+
 This ensures cuimp can properly verify TLS certificates inside the container.
 
 ## 📄 License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuimp",
-  "version": "1.5.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cuimp",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.4.3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Docker troubleshooting guidance for TLS certificate verification inside containers.
> 
> - **Documentation**:
>   - **README**: Add a new Docker troubleshooting section for TLS certificate verification errors ("error setting certificate verify locations"), advising mounting host CA certs via `volumes: - /etc/ssl/certs:/etc/ssl/certs:ro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f40d91f50609d880b7e357b55f219c15fbdfa396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->