### PR TITLE
fix: prevent parseHttpResponse from treating body content as headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuimp",
-  "version": "1.9.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cuimp",
-      "version": "1.9.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "tar": "7.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuimp",
-  "version": "1.9.0",
+  "version": "1.10.1",
   "description": "Node wrapper for curl-impersonate (lexiforest) via CLI - Enhanced with raw buffer support and extra curl args",
   "keywords": [
     "cuimp",

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -859,79 +859,49 @@ export function parseHttpResponse(stdoutBuf: Buffer): {
   headers: Record<string, string>
   body: Buffer
 } {
-  const httpMarker = Buffer.from('HTTP/')
-
-  // Find all positions where HTTP responses start
-  const httpStarts: number[] = []
-  for (let i = 0; i <= stdoutBuf.length - 5; i++) {
-    if (stdoutBuf.slice(i, i + 5).equals(httpMarker)) {
-      httpStarts.push(i)
-    }
-  }
-
-  if (httpStarts.length === 0) {
+  if (!isHttpStatusLine(stdoutBuf)) {
     const previewText = stdoutBuf.toString('utf8', 0, Math.min(500, stdoutBuf.length))
     throw new Error(`No HTTP response found:\n${previewText}`)
   }
 
-  // Find header/body separator
-  const separator1 = Buffer.from('\r\n\r\n')
-  const separator2 = Buffer.from('\n\n')
+  let offset = 0
+  let response: ParsedHttpHeaders | null = null
 
-  let lastHeaderEnd = 0
-  let lastHeaderEndLength = 0
+  while (offset < stdoutBuf.length) {
+    const remaining = stdoutBuf.subarray(offset)
+    if (!isHttpStatusLine(remaining)) {
+      break
+    }
 
-  for (const httpStart of httpStarts) {
-    let found = false
-    for (let i = httpStart; i < stdoutBuf.length; i++) {
-      if (i + 4 <= stdoutBuf.length && stdoutBuf.slice(i, i + 4).equals(separator1)) {
-        lastHeaderEnd = i
-        lastHeaderEndLength = 4
-        found = true
-        break
-      } else if (i + 2 <= stdoutBuf.length && stdoutBuf.slice(i, i + 2).equals(separator2)) {
-        lastHeaderEnd = i
-        lastHeaderEndLength = 2
-        found = true
-        break
+    const separator = findHeaderSeparator(remaining)
+    if (!separator) {
+      response = parseHttpHeaderBlock(remaining.toString('utf8'))
+      return {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        body: Buffer.alloc(0),
       }
     }
-    if (!found) {
-      lastHeaderEnd = stdoutBuf.length
-      lastHeaderEndLength = 0
+
+    const headerBuf = remaining.subarray(0, separator.index)
+    response = parseHttpHeaderBlock(headerBuf.toString('utf8'))
+    offset += separator.index + separator.length
+
+    if (!isHttpStatusLine(stdoutBuf.subarray(offset))) {
+      break
     }
   }
 
-  // Extract headers and body
-  const headerBuf = stdoutBuf.slice(0, lastHeaderEnd)
-  const rawBody = stdoutBuf.slice(lastHeaderEnd + lastHeaderEndLength)
-  const headerText = headerBuf.toString('utf8')
-
-  // Handle multiple header blocks (redirects)
-  const httpBlocks = headerText.split(/(?=HTTP\/)/)
-  const validBlocks = httpBlocks.filter(
-    block => block.trim() && /^HTTP\/[1-3](?:\.\d)? \d{3}/.test(block.trim())
-  )
-
-  const lastBlock = validBlocks.length ? validBlocks[validBlocks.length - 1] : headerText
-  const cleanBlock = lastBlock.replace(/\r?\n\r?\n$/, '')
-
-  // Parse status + headers
-  const headerLines = cleanBlock.split(/\r?\n/)
-  const statusLine = headerLines.shift() || 'HTTP/1.1 200 OK'
-  const m = statusLine.match(/^HTTP\/\d(?:\.\d)?\s+(\d{3})(?:\s+(.*))?$/)
-  const status = m ? parseInt(m[1], 10) : 200
-  const statusText = getStatusText(status, m?.[2])
-
-  const headers: Record<string, string> = {}
-  for (const line of headerLines) {
-    const idx = line.indexOf(':')
-    if (idx > 0) {
-      const k = line.slice(0, idx).trim().toLowerCase()
-      const v = line.slice(idx + 1).trim()
-      headers[k] = v
-    }
+  if (!response) {
+    const previewText = stdoutBuf.toString('utf8', 0, Math.min(500, stdoutBuf.length))
+    throw new Error(`No HTTP response found:\n${previewText}`)
   }
 
-  return { status, statusText, headers, body: rawBody }
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    body: stdoutBuf.subarray(offset),
+  }
 }

--- a/test/unit/parser.test.ts
+++ b/test/unit/parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { parseDescriptor, createHttpResponseStreamParser } from '../../src/helpers/parser'
+import {
+  parseDescriptor,
+  createHttpResponseStreamParser,
+  parseHttpResponse,
+} from '../../src/helpers/parser'
 import { CuimpDescriptor } from '../../src/types/cuimpTypes'
 
 // Mock the connector module
@@ -550,5 +554,24 @@ describe('createHttpResponseStreamParser', () => {
       expect(headersReceived).toHaveLength(1)
       expect(headersReceived[0].status).toBe(200)
     })
+  })
+})
+
+describe('parseHttpResponse', () => {
+  it('should not parse JSON body lines as headers after redirects', () => {
+    const stdout = Buffer.from(
+      'HTTP/1.1 302 Found\r\nLocation: /redirect\r\n\r\n' +
+        'HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\n\r\n' +
+        '{"count":123,"data":[{"key":"HTTP/1.1 200 text inside body"}]}'
+    )
+
+    const response = parseHttpResponse(stdout)
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8')
+    expect(response.headers['{"count"']).toBeUndefined()
+    expect(response.body.toString('utf8')).toBe(
+      '{"count":123,"data":[{"key":"HTTP/1.1 200 text inside body"}]}'
+    )
   })
 })


### PR DESCRIPTION
## Summary

- fix `parseHttpResponse` so it parses curl stdout sequentially instead of scanning for `HTTP/` anywhere in the body
- align non-stream response parsing with the safer boundary detection already used by the streaming parser
- add a regression test covering redirected JSON responses that contain `HTTP/...` text in the body

## Problem

The non-stream parser could treat body content as another HTTP response block when the response body contained `HTTP/...` text. That could shift the header/body boundary and cause JSON body lines to be parsed into `headers`, producing bogus keys like `{"count"` (slice from first `:` found).

## Solution

This change updates `parseHttpResponse` to:

- require the buffer to begin with a valid HTTP status line
- parse header blocks sequentially from the front
- only continue parsing another response block when the next bytes also begin with a valid HTTP status line
- treat the remaining bytes as the final body otherwise

## Testing

- added a regression test in `test/unit/parser.test.ts` for redirected JSON responses containing `HTTP/1.1 200` inside the body
