### PR TITLE
fix: Add Android/Termux platform support

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -13,6 +13,14 @@ import { fileURLToPath } from 'url'
 import { execSync } from 'child_process'
 
 /**
+ * Purpose: Detect host platform and manage curl-impersonate binary lookup/download.
+ * Caller: parseDescriptor() callers from cuimp/client public APIs.
+ * Dependencies: fs, path, os, tar extraction, GitHub release connector, descriptor normalization.
+ * Main Functions: getSystemInfo, parseDescriptor, buildDownloadAssetName, resolveBinaryTarget.
+ * Side Effects: Reads host filesystem, downloads release assets, writes binaries under user home.
+ */
+
+/**
  * Detects if the system uses musl libc (Alpine Linux, etc.) instead of glibc
  * This is important for downloading the correct binary
  */
@@ -91,6 +99,8 @@ function getPackageDir(): string {
 
 // Binary search paths in order of preference
 const BINARY_SEARCH_PATHS = [
+  '/data/data/com.termux/files/usr/bin/',
+  '/data/data/com.termux/files/usr/local/bin/',
   '/usr/local/bin/',
   '/usr/bin/',
   '/bin/',
@@ -534,6 +544,25 @@ const downloadAndExtractBinary = async (
 }
 
 /**
+ * Detects Termux Android from stable environment and filesystem markers.
+ */
+const isTermux = (): boolean => {
+  if (process.env.TERMUX_VERSION) {
+    return true
+  }
+
+  if (process.env.PREFIX?.includes('/data/data/com.termux')) {
+    return true
+  }
+
+  try {
+    return fs.existsSync('/data/data/com.termux/files/usr')
+  } catch {
+    return false
+  }
+}
+
+/**
  * Determines the appropriate architecture and platform for the current system
  */
 export const getSystemInfo = (): { architecture: string; platform: string } => {
@@ -550,13 +579,14 @@ export const getSystemInfo = (): { architecture: string; platform: string } => {
   }
 
   const platformMap: Record<string, string> = {
+    android: 'android',
     linux: 'linux',
     win32: 'windows',
     darwin: 'macos',
   }
 
   const mappedArch = archMap[arch]
-  const mappedPlatform = platformMap[platform]
+  let mappedPlatform = platformMap[platform]
 
   if (!mappedArch) {
     throw new Error(`Unsupported architecture: ${arch}`)
@@ -564,6 +594,10 @@ export const getSystemInfo = (): { architecture: string; platform: string } => {
 
   if (!mappedPlatform) {
     throw new Error(`Unsupported platform: ${platform}`)
+  }
+
+  if (mappedPlatform === 'linux' && isTermux()) {
+    mappedPlatform = 'android'
   }
 
   return {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -5,6 +5,14 @@ import path from 'node:path'
 import fs from 'node:fs'
 
 /**
+ * Purpose: Run curl-impersonate binaries and wrapper scripts.
+ * Caller: HTTP client request execution paths.
+ * Dependencies: node child_process, path, fs, curl-impersonate wrapper scripts.
+ * Main Functions: runBinary, runBinaryStream.
+ * Side Effects: Spawns child processes and writes optional stdin.
+ */
+
+/**
  * Parses a .bat file to extract curl arguments
  * Handles line continuations (^) and extracts all arguments after curl.exe
  * @param batFilePath Path to the .bat file
@@ -365,6 +373,26 @@ function mergeHeaderArguments(batArgs: string[], userArgs: string[]): string[] {
   return merged
 }
 
+function parseUnixWrapper(wrapperPath: string): { binaryPath: string; args: string[] } | null {
+  const content = fs.readFileSync(wrapperPath, 'utf8')
+  const command = content.match(/"\$dir\/curl-impersonate"\s+([\s\S]*?)"\$@"/)
+  if (!command) return null
+
+  const scriptDir = path.dirname(wrapperPath)
+  const binaryPath = path.join(scriptDir, 'curl-impersonate')
+  if (!fs.existsSync(binaryPath)) return null
+
+  const args = parseBatArguments(
+    command[1]
+      .replace(/\\\s*\n/g, ' ')
+      .replace(/\n/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+
+  return { binaryPath, args }
+}
+
 export function runBinary(
   binPath: string,
   args: string[],
@@ -378,6 +406,18 @@ export function runBinary(
     let actualBinPath = cleanPath
     let finalArgs = args
     let needsShell = false
+
+    if (!isWindows) {
+      try {
+        const wrapper = parseUnixWrapper(cleanPath)
+        if (wrapper) {
+          actualBinPath = wrapper.binaryPath
+          finalArgs = mergeHeaderArguments(wrapper.args, args)
+        }
+      } catch {
+        // Run the original executable when it is not a curl-impersonate wrapper.
+      }
+    }
 
     if (isWindows && isBatFile) {
       try {
@@ -554,6 +594,18 @@ export function runBinaryStream(
     let actualBinPath = cleanPath
     let finalArgs = args
     let needsShell = false
+
+    if (!isWindows) {
+      try {
+        const wrapper = parseUnixWrapper(cleanPath)
+        if (wrapper) {
+          actualBinPath = wrapper.binaryPath
+          finalArgs = mergeHeaderArguments(wrapper.args, args)
+        }
+      } catch {
+        // Run the original executable when it is not a curl-impersonate wrapper.
+      }
+    }
 
     if (isWindows && isBatFile) {
       try {

--- a/test/unit/mobilePlatforms.test.ts
+++ b/test/unit/mobilePlatforms.test.ts
@@ -1,12 +1,44 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import { validateDescriptor } from '../../src/validations/descriptorValidation'
 import { resolveBinaryTarget } from '../../src/helpers/descriptorNormalize'
-import { buildDownloadAssetName } from '../../src/helpers/parser'
+import { buildDownloadAssetName, getSystemInfo } from '../../src/helpers/parser'
+
+/**
+ * Purpose: Covers mobile platform descriptor and host-detection regressions.
+ * Caller: Vitest mobile platform test script.
+ * Dependencies: descriptor validation, descriptor normalization, parser helpers.
+ * Main Functions: mobile platform and Termux Android assertions.
+ * Side Effects: Temporarily mutates process.env for host detection tests.
+ */
 
 /**
  * Regression coverage for issue #40 (iOS platform + Safari 2601).
  */
+const originalTermuxVersion = process.env.TERMUX_VERSION
+const originalPrefix = process.env.PREFIX
+const originalPlatform = process.platform
+
+const restoreTermuxEnv = (): void => {
+  if (originalTermuxVersion === undefined) {
+    delete process.env.TERMUX_VERSION
+  } else {
+    process.env.TERMUX_VERSION = originalTermuxVersion
+  }
+
+  if (originalPrefix === undefined) {
+    delete process.env.PREFIX
+  } else {
+    process.env.PREFIX = originalPrefix
+  }
+
+  Object.defineProperty(process, 'platform', { value: originalPlatform })
+}
+
 describe('mobile platforms (issue #40)', () => {
+  afterEach(() => {
+    restoreTermuxEnv()
+  })
+
   it('accepts reporter config: safari 2601 on iOS', () => {
     expect(() =>
       validateDescriptor({ browser: 'safari', version: '2601', platform: 'iOS' })
@@ -50,5 +82,29 @@ describe('mobile platforms (issue #40)', () => {
     expect(buildDownloadAssetName('v1.0.0', 'x64', 'android')).toBe(
       'curl-impersonate-v1.0.0.x86_64-linux-android.tar.gz'
     )
+  })
+
+  it('detects native Android Node platform', () => {
+    Object.defineProperty(process, 'platform', { value: 'android' })
+    delete process.env.TERMUX_VERSION
+    delete process.env.PREFIX
+
+    expect(getSystemInfo().platform).toBe('android')
+  })
+
+  it('detects Termux Android from TERMUX_VERSION', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    process.env.TERMUX_VERSION = '0.118.2'
+    delete process.env.PREFIX
+
+    expect(getSystemInfo().platform).toBe('android')
+  })
+
+  it('detects Termux Android from PREFIX', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    delete process.env.TERMUX_VERSION
+    process.env.PREFIX = '/data/data/com.termux/files/usr'
+
+    expect(getSystemInfo().platform).toBe('android')
   })
 })

--- a/test/unit/runner.test.ts
+++ b/test/unit/runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { runBinary } from '../../src/runner'
 import { spawn } from 'node:child_process'
+import fs from 'node:fs'
 import path from 'node:path'
 
 // Mock child_process
@@ -56,6 +57,7 @@ function restorePlatform(originalPlatform: string): boolean {
 
 describe('runBinary', () => {
   const mockSpawn = vi.mocked(spawn)
+  const originalPlatform = process.platform
   let mockChildProcess: any
 
   beforeEach(() => {
@@ -77,7 +79,39 @@ describe('runBinary', () => {
   })
 
   afterEach(() => {
+    restorePlatform(originalPlatform)
     vi.restoreAllMocks()
+  })
+
+  it('should run Unix wrapper scripts through curl-impersonate directly', async () => {
+    if (!mockPlatform('android')) {
+      return
+    }
+
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(`#!/usr/bin/env bash
+
+# Find the directory of this script
+dir=\${0%/*}
+
+"$dir/curl-impersonate" --compressed --impersonate "chrome146" "$@"
+`)
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+
+    mockChildProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        setTimeout(() => callback(0), 10)
+      }
+    })
+    mockChildProcess.stdout.on.mockImplementation(() => {})
+    mockChildProcess.stderr.on.mockImplementation(() => {})
+
+    await runBinary('/home/.cuimp/binaries/curl_chrome146', ['https://example.com'])
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      path.join('/home/.cuimp/binaries', 'curl-impersonate'),
+      ['--compressed', '--impersonate', 'chrome146', 'https://example.com'],
+      expect.objectContaining({ shell: false })
+    )
   })
 
   it('should resolve with successful result', async () => {


### PR DESCRIPTION
This commit fixes two issues preventing cuimp from running on Android environments (such as Termux):

1. Platform Detection: Map native Android Node.js platform identifier
   - Add android -> android mapping in platformMap
   - Node.js v25+ on Android reports process.platform === "android"

2. Wrapper Execution: Parse Unix wrapper scripts and spawn binary directly
   - Add parseUnixWrapper() to extract curl-impersonate path and args
   - Bypass shebang dependency on /usr/bin/env (missing in Termux)
   - Apply same wrapper-parsing approach used for Windows .bat files

Test coverage:
- Add native Android platform detection test
- Add Unix wrapper parsing test
- All 45 existing tests pass

Fixes issues reported in Android/Termux environments where:
- Error 1: "Unsupported platform: android"
- Error 2: "spawn ENOENT" on wrapper scripts

Update:
Fix #46 