### PR TITLE
fix: add windowsHide to spawn to suppress console window flash on Windows

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -527,6 +527,8 @@ export function runBinary(
 
     const child = spawn(actualBinPath, finalArgs, {
       stdio: [opts?.stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      // Suppress the transient console window on Windows. No-op on other platforms.
+      windowsHide: true,
       shell: needsShell,
     })
 
@@ -687,6 +689,8 @@ export function runBinaryStream(
 
     const child = spawn(actualBinPath, finalArgs, {
       stdio: [opts?.stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      // Suppress the transient console window on Windows. No-op on other platforms.
+      windowsHide: true,
       shell: needsShell,
     })
 

--- a/test/unit/runner.test.ts
+++ b/test/unit/runner.test.ts
@@ -161,6 +161,37 @@ dir=\${0%/*}
     )
   })
 
+  it('should spawn with windowsHide to suppress the console window on Windows', async () => {
+    const mockStdout = Buffer.from('output data')
+    const mockStderr = Buffer.from('')
+
+    mockChildProcess.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'close') {
+        setTimeout(() => callback(0), 10)
+      }
+    })
+    mockChildProcess.stdout.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'data') {
+        setTimeout(() => callback(mockStdout), 5)
+      }
+    })
+    mockChildProcess.stderr.on.mockImplementation((event: string, callback: Function) => {
+      if (event === 'data') {
+        setTimeout(() => callback(mockStderr), 5)
+      }
+    })
+
+    await runBinary('/usr/bin/curl-impersonate', ['-X', 'GET', 'https://example.com'])
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/usr/bin/curl-impersonate',
+      ['-X', 'GET', 'https://example.com'],
+      expect.objectContaining({
+        windowsHide: true,
+      })
+    )
+  })
+
   it('should handle process error', async () => {
     const error = new Error('Process failed to start')
 


### PR DESCRIPTION
Closes #50

Hi! 👋

While exploring the ecosystem, I came across **cuimp** and started using it. It's a great library, and I noticed that issue #50 (opened by @linguo2625469) was still open, so I decided to put together a small fix and contribute back.

## Problem

On Windows, every request briefly flashes a `cmd.exe` console window because the `spawn()` calls that launch the `curl-impersonate` binary don't set the `windowsHide` option.

## Solution

Added `windowsHide: true` to both `spawn()` calls in `src/runner.ts`:

- `runBinary()`
- `runBinaryStream()`

`windowsHide` is a built-in `child_process.spawn()` option (supported in Node.js 14+) and is a no-op on non-Windows platforms, so this change does not affect Linux or macOS behavior.

## Tests

- Added a unit test to verify that `spawn()` is called with `windowsHide: true`.
- Verified that the following commands pass locally:
  - `npm run typecheck`
  - `npm run eslint`
  - `npm run build`

Thanks for maintaining such a great library! Looking forward to using it more.